### PR TITLE
Make appVersion Text instead of Data.Version.Version

### DIFF
--- a/src/Network/Bugsnag/App.hs
+++ b/src/Network/Bugsnag/App.hs
@@ -7,14 +7,13 @@ module Network.Bugsnag.App
 import Data.Aeson
 import Data.Aeson.Ext
 import Data.Text (Text)
-import Data.Version
 import GHC.Generics
 import Network.Bugsnag.ReleaseStage
 import Numeric.Natural
 
 data BugsnagApp = BugsnagApp
     { baId :: Maybe Text
-    , baVersion :: Maybe Version
+    , baVersion :: Maybe Text
     , baBuildUUID :: Maybe Text
     , baReleaseStage :: Maybe BugsnagReleaseStage
     , baType :: Maybe Text

--- a/src/Network/Bugsnag/Settings.hs
+++ b/src/Network/Bugsnag/Settings.hs
@@ -15,7 +15,6 @@ import Data.Aeson (FromJSON)
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Version
 import Network.Bugsnag.BeforeNotify
 import Network.Bugsnag.Event
 import Network.Bugsnag.Exception
@@ -39,7 +38,7 @@ instance Show BugsnagApiKey where
 data BugsnagSettings = BugsnagSettings
     { bsApiKey :: BugsnagApiKey
     -- ^ Your Integration API Key.
-    , bsAppVersion :: Maybe Version
+    , bsAppVersion :: Maybe Text
     -- ^ The version of your application
     --
     -- Marking bugs as Fixed and having them auto-reopen in new versions

--- a/test/Network/Bugsnag/ReportSpec.hs
+++ b/test/Network/Bugsnag/ReportSpec.hs
@@ -10,7 +10,6 @@ import Data.Aeson
 import Data.Aeson.QQ (aesonQQ)
 import Data.Text (Text)
 import Data.Time (getCurrentTime)
-import Data.Version (makeVersion)
 import Network.Bugsnag
 
 spec :: Spec
@@ -102,7 +101,7 @@ spec = do
                                     }
                                 , beApp = Just bugsnagApp
                                     { baId = Just "1"
-                                    , baVersion = Just $ makeVersion [1, 0, 0]
+                                    , baVersion = Just "1.0.0"
                                     }
                                 , beDevice = Nothing
                                 , beMetaData = Just $ object


### PR DESCRIPTION
* This allows using e.g. Git SHAs as the version, for users who deploy on every commit instead of assigning version numbers
* This better reflects Bugsnag's API which allows for arbitrary version numbers, without an a.b.c convention