### PR TITLE
Move request header redacting

### DIFF
--- a/src/Network/Bugsnag/Settings.hs
+++ b/src/Network/Bugsnag/Settings.hs
@@ -51,9 +51,7 @@ data BugsnagSettings = BugsnagSettings
     , bsBeforeNotify :: BeforeNotify
     -- ^ Modify any events before they are sent
     --
-    -- For example to attach a user, or set the context. By default, we use
-    -- @'redactRequestHeaders'@ to strip some sensitive Headers from the
-    -- Request.
+    -- For example to attach a user, or set the context.
     --
     , bsIgnoreException :: BugsnagException -> Bool
     -- ^ Exception filtering
@@ -84,7 +82,7 @@ bugsnagSettings apiKey manager = BugsnagSettings
     , bsAppVersion = Nothing
     , bsReleaseStage = ProductionReleaseStage
     , bsNotifyReleaseStages = [ProductionReleaseStage]
-    , bsBeforeNotify = defaultBeforeNotify
+    , bsBeforeNotify = id
     , bsIgnoreException = const False
     , bsHttpManager = manager
     , bsCodeIndex = Nothing


### PR DESCRIPTION
In the main notify routine, the before-notify composition places the
most local function (the one passed directly to notifyWith) last in the
change, after the one coming from Settings. To do otherwise could be
surprising.

Since updateEventFromWaiRequest is almost-certainly used as an argument
to notifyWith, it sets the Event Request /after/ the Settings hook has
run. Therefore, placing the header redaction as a default in Settings in
an effort to ensure it always runs was misguided: it has no effect.

This change moves the redaction into the before-notify dealing with the
WAI Request itself:

- There's not (currently) any other (endorsed) way to set the Event
  Request, so there's no need to redact /except/ in this function
- Doing it this way should ensure we don't mess up the ordering
- An Unredacted version was exported just in case that's useful

Fixes #31 for real.

NOTE: we really should have a way to put a regression test on this.