### PR TITLE
Tag SomeException with the underlying exception class

### DIFF
--- a/src/Network/Bugsnag/Exception.hs
+++ b/src/Network/Bugsnag/Exception.hs
@@ -86,24 +86,6 @@ exCasters :: [Caster]
 exCasters =
     [ Caster id
     , Caster $ bugsnagExceptionWithParser parseErrorCall
-    , Caster $ bugsnagExceptionFromException @IOException
-    , Caster $ bugsnagExceptionFromException @ArithException
-    , Caster $ bugsnagExceptionFromException @ArrayException
-    , Caster $ bugsnagExceptionFromException @AssertionFailed
-    , Caster $ bugsnagExceptionFromException @SomeAsyncException
-    , Caster $ bugsnagExceptionFromException @AsyncException
-    , Caster $ bugsnagExceptionFromException @NonTermination
-    , Caster $ bugsnagExceptionFromException @NestedAtomically
-    , Caster $ bugsnagExceptionFromException @BlockedIndefinitelyOnMVar
-    , Caster $ bugsnagExceptionFromException @BlockedIndefinitelyOnSTM
-    , Caster $ bugsnagExceptionFromException @AllocationLimitExceeded
-    , Caster $ bugsnagExceptionFromException @Deadlock
-    , Caster $ bugsnagExceptionFromException @NoMethodError
-    , Caster $ bugsnagExceptionFromException @PatternMatchFail
-    , Caster $ bugsnagExceptionFromException @RecConError
-    , Caster $ bugsnagExceptionFromException @RecSelError
-    , Caster $ bugsnagExceptionFromException @RecUpdError
-    , Caster $ bugsnagExceptionFromException @TypeError
     ]
 
 bugsnagExceptionWithParser

--- a/src/Network/Bugsnag/Exception.hs
+++ b/src/Network/Bugsnag/Exception.hs
@@ -73,11 +73,14 @@ bugsnagException errorClass message stacktrace = BugsnagException
 -- ("IOException",Just "user error (Oops)")
 --
 bugsnagExceptionFromSomeException :: SomeException -> BugsnagException
-bugsnagExceptionFromSomeException ex =
-    foldr go (bugsnagExceptionWithParser parseStringException ex) exCasters
-  where
+bugsnagExceptionFromSomeException ex = foldr go seed exCasters
+ where
     go :: Caster -> BugsnagException -> BugsnagException
     go (Caster caster) res = maybe res caster $ fromException ex
+
+    seed = (bugsnagExceptionWithParser parseStringException ex)
+        { beErrorClass = (\(SomeException e) -> exErrorClass e) ex
+        }
 
 exCasters :: [Caster]
 exCasters =

--- a/test/Network/BugsnagSpec.hs
+++ b/test/Network/BugsnagSpec.hs
@@ -78,7 +78,7 @@ spec = do
                 e <- brokenFunction' `catch` pure
 
                 let ex = bugsnagExceptionFromSomeException e
-                beErrorClass ex `shouldBe` "SomeException"
+                beErrorClass ex `shouldBe` "StringException"
                 beMessage ex `shouldBe` Just "empty list"
                 beStacktrace ex `shouldSatisfy` ((== 3) . length)
 
@@ -95,7 +95,7 @@ spec = do
                 e <- brokenFunction'' `catch` pure
 
                 let ex = bugsnagExceptionFromSomeException e
-                beErrorClass ex `shouldBe` "SomeException"
+                beErrorClass ex `shouldBe` "StringException"
                 beMessage ex `shouldBe` Just
                     "empty list\n and message with newlines\n\n"
                 beStacktrace ex `shouldSatisfy` ((== 3) . length)


### PR DESCRIPTION
The library was calling `exErrorClass` on the `SomeException`. This is
fine, but it always exposes a `SomeException` constructor tag. Since
`SomeException` is an existential type of `Exception`, which has a
superclass of `Typeable`, we can open up the constructor and call
`exErrorClass` on the inner type without ambiguity.

This requires somewhat of an awkward formulation to work properly. The
original `bugsnagExceptionWithParser` call uses `SomeException` via
`parseStringException`, so we must first create a `BugsnagException` and
then edit it with our existential tag. The `SomeException` must be
unwrapped to do this, so we need apply a lambda to do so.