### PR TITLE
Use stack-build-minimal on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,8 @@ version: 2.0
 references:
   stack_build: &stack_build
     docker:
-      - image: fpco/stack-build:lts
+      - image: quay.io/haskell_works/stack-build-minimal
     steps:
-      - run:
-          name: Upgrade stack
-          command: stack upgrade
-
       - checkout
       - run:
           name: Digest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ references:
       - run:
           name: Dependencies
           command: |
+            # Needed for pcre-light transitive
+            sudo apt-get update -y
+            sudo apt-get install -y libpcre3-dev
+
             make setup
 
             if [ "${LINT:-1}" = 1 ]; then


### PR DESCRIPTION
Latest fpco/stack-build is missing the stack executable. Unclear why.