### PR TITLE
Warn of compile time impact of buildCodeIndex

### DIFF
--- a/src/Network/Bugsnag/CodeIndex.hs
+++ b/src/Network/Bugsnag/CodeIndex.hs
@@ -25,6 +25,10 @@ newtype CodeIndex = CodeIndex
     { unCodeIndex :: Map FilePath FileIndex }
     deriving (Lift, Show)
 
+-- | Builds an index of code that can be used to attach information; see the @bsCodeIndex@ field of @BugsnagSettings@.
+--
+-- Warning: In larger projects, this will embed substantial amounts of source code in a single file.
+-- This can significantly degrade compilation time, so use with caution.
 buildCodeIndex :: String -> Q Exp
 buildCodeIndex p = do
     index <- qRunIO $ buildCodeIndex' p

--- a/src/Network/Bugsnag/CodeIndex.hs
+++ b/src/Network/Bugsnag/CodeIndex.hs
@@ -25,10 +25,9 @@ newtype CodeIndex = CodeIndex
     { unCodeIndex :: Map FilePath FileIndex }
     deriving (Lift, Show)
 
--- | Builds an index of code that can be used to attach information; see the @bsCodeIndex@ field of @BugsnagSettings@.
+-- | Builds an index of code that can be used to attach lines of source code contex to stacktraces; see the @bsCodeIndex@ field of @BugsnagSettings@ for details.
 --
--- Warning: In larger projects, this will embed substantial amounts of source code in a single file.
--- This can significantly degrade compilation time, so use with caution.
+-- Warning: In larger projects, this will embed substantial amounts of source code in a single file, which can significantly degrade compilation time.
 buildCodeIndex :: String -> Q Exp
 buildCodeIndex p = do
     index <- qRunIO $ buildCodeIndex' p


### PR DESCRIPTION
I noticed this was getting pretty slow for us at work, and I figured I should warn others about it. For us, it was embedding something like 145K lines in a single file! I used `-ddump-splices -ddump-to-file` to see the generated code.