### PR TITLE
Support ghc-9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ jobs:
     strategy:
       matrix:
         stack-yaml:
-          - stack.yaml
-          - stack-nightly.yaml
-          - stack-lts-20.26.yaml
-          - stack-lts-18.28.yaml
-          - stack-lts-16.31.yaml
-          - stack-lts-14.27.yaml
-          - stack-lts-12.26.yaml
+          - stack-nightly.yaml   # ghc-9.8
+          - stack.yaml           # ghc-9.6
+          - stack-lts-21.25.yaml # ghc-9.4
+          - stack-lts-20.26.yaml # ghc-9.2
+          - stack-lts-18.28.yaml # ghc-9.0
+          - stack-lts-16.31.yaml # ghc-8.8
+          - stack-lts-14.27.yaml # ghc-8.6
+          - stack-lts-12.26.yaml # ghc-8.4
       fail-fast: false
 
     steps:

--- a/bugsnag/test/Network/Bugsnag/ExceptionSpec.hs
+++ b/bugsnag/test/Network/Bugsnag/ExceptionSpec.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Network.Bugsnag.ExceptionSpec
   ( spec
@@ -22,7 +22,7 @@ spec = do
       exception_message ex `shouldBe` Just "Something exploded"
       exception_stacktrace ex `shouldSatisfy` (not . null)
 
-      let frame = head $ exception_stacktrace ex
+      let (frame : _) = exception_stacktrace ex
       stackFrame_file frame `shouldBe` "test/Examples.hs"
       stackFrame_lineNumber frame `shouldBe` 28
       -- different versions of GHC disagree on where splices start
@@ -49,7 +49,7 @@ spec = do
       exception_message ex `shouldBe` Just "empty list"
       exception_stacktrace ex `shouldSatisfy` ((== 3) . length)
 
-      let frame = head $ exception_stacktrace ex
+      let (frame : _) = exception_stacktrace ex
       stackFrame_file frame `shouldBe` "test/Examples.hs"
       stackFrame_lineNumber frame `shouldBe` 36
       stackFrame_columnNumber frame `shouldBe` Just 15
@@ -66,7 +66,7 @@ spec = do
       exception_message ex `shouldBe` Just "empty list"
       exception_stacktrace ex `shouldSatisfy` ((== 3) . length)
 
-      let frame = head $ exception_stacktrace ex
+      let (frame : _) = exception_stacktrace ex
       stackFrame_file frame `shouldBe` "test/Examples.hs"
       stackFrame_lineNumber frame `shouldBe` 43
       stackFrame_columnNumber frame `shouldBe` Just 16
@@ -85,7 +85,7 @@ spec = do
           "empty list\n and message with newlines\n\n"
       exception_stacktrace ex `shouldSatisfy` ((== 3) . length)
 
-      let frame = head $ exception_stacktrace ex
+      let (frame : _) = exception_stacktrace ex
       stackFrame_file frame `shouldBe` "test/Examples.hs"
       stackFrame_lineNumber frame `shouldBe` 50
       stackFrame_columnNumber frame `shouldBe` Just 17
@@ -105,7 +105,7 @@ spec = do
       exception_message ex `shouldBe` Just "empty list"
       exception_stacktrace ex `shouldSatisfy` ((== 2) . length)
 
-      let frame = head $ exception_stacktrace ex
+      let (frame : _) = exception_stacktrace ex
       stackFrame_file frame `shouldBe` "test/Examples.hs"
       stackFrame_lineNumber frame `shouldBe` 53
       stackFrame_columnNumber frame `shouldBe` Just 27

--- a/bugsnag/test/Network/Bugsnag/ExceptionSpec.hs
+++ b/bugsnag/test/Network/Bugsnag/ExceptionSpec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial #-}
+
 module Network.Bugsnag.ExceptionSpec
   ( spec
   ) where

--- a/stack-lts-12.26.yaml.lock
+++ b/stack-lts-12.26.yaml.lock
@@ -5,22 +5,29 @@
 
 packages:
 - completed:
+    hackage: annotated-exception-0.2.0.2@sha256:cb55b4b9f5797219935a9047d5534fd4cb5ae9f3f153108908a4d737192afe83,1785
+    pantry-tree:
+      sha256: 5f840fc82d58ab1d8a81e1ae3a2350d62a19d5a17056fe7db15dfebebe486011
+      size: 776
+  original:
+    hackage: annotated-exception-0.2.0.2
+- completed:
     hackage: bugsnag-hs-0.2.0.8@sha256:978e699292a3910040f1525335284fb066c1c81f82130769df146c134dfecc64,1525
     pantry-tree:
-      size: 456
       sha256: b3959ee9116623e6a44a842521bd8a4396549d22c118d249d77ebc02c6ab8630
+      size: 456
   original:
     hackage: bugsnag-hs-0.2.0.8
 - completed:
     hackage: ua-parser-0.7.7.0@sha256:c79b871fe57109afe988c965fddfeaf21892afbe38b5644519d898768f742cb2,2651
     pantry-tree:
-      size: 1390
       sha256: 6f38f1c6aa6130c23847be326ab50bbdb257bd347c74b61ffc95981facf692f9
+      size: 1390
   original:
     hackage: ua-parser-0.7.7.0
 snapshots:
 - completed:
+    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
     size: 509471
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/12/26.yaml
-    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
   original: lts-12.26

--- a/stack-lts-14.27.yaml.lock
+++ b/stack-lts-14.27.yaml.lock
@@ -5,15 +5,22 @@
 
 packages:
 - completed:
+    hackage: annotated-exception-0.2.0.3@sha256:3b648717c060cf808435738d85e94e78b144eb8267c281c8cc87edb99a18393e,1785
+    pantry-tree:
+      sha256: 4412649314f4bebda75c31bc2f6bcb56701af2eea04218e678709b440179055e
+      size: 776
+  original:
+    hackage: annotated-exception-0.2.0.3
+- completed:
     hackage: bugsnag-hs-0.2.0.8@sha256:978e699292a3910040f1525335284fb066c1c81f82130769df146c134dfecc64,1525
     pantry-tree:
-      size: 456
       sha256: b3959ee9116623e6a44a842521bd8a4396549d22c118d249d77ebc02c6ab8630
+      size: 456
   original:
     hackage: bugsnag-hs-0.2.0.8
 snapshots:
 - completed:
+    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
     size: 524996
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
-    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
   original: lts-14.27

--- a/stack-lts-16.31.yaml.lock
+++ b/stack-lts-16.31.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: annotated-exception-0.2.0.4@sha256:3d499515d64d64ecc1a43a8ebbc70b24020e1ed2cbf8726039d282d87d8cb0ed,1785
+    pantry-tree:
+      sha256: f3080caecc6e12cd3d341f56732ef8528f2b8dd2e7230d86453cbdac5d406736
+      size: 776
+  original:
+    hackage: annotated-exception-0.2.0.4
 snapshots:
 - completed:
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
     size: 534126
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
-    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
   original: lts-16.31

--- a/stack-lts-20.26.yaml.lock
+++ b/stack-lts-20.26.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: annotated-exception-0.2.0.5@sha256:d8d343f556e67ac38c8b5c8b9a1d551dd8005f6d28fe9c2accd606c5f9070e24,1785
-    pantry-tree:
-      sha256: 7e8f91d0899402a6ede549e6a47b169fdc9bb9877f4fe52471c2f43ef05eb167
-      size: 776
-  original:
-    hackage: annotated-exception-0.2.0.5
+packages: []
 snapshots:
 - completed:
     sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2

--- a/stack-lts-21.25.yaml
+++ b/stack-lts-21.25.yaml
@@ -1,0 +1,7 @@
+resolver: lts-21.25
+packages:
+  - bugsnag
+  - bugsnag-wai
+  - bugsnag-yesod
+extra-deps:
+  - annotated-exception-0.2.0.5

--- a/stack-lts-21.25.yaml.lock
+++ b/stack-lts-21.25.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: annotated-exception-0.2.0.5
 snapshots:
 - completed:
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
-    size: 590100
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
-  original: lts-18.28
+    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
+    size: 640086
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
+  original: lts-21.25

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-11-01
+resolver: nightly-2024-01-02
 packages:
   - bugsnag
   - bugsnag-wai

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 539378
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/3/30.yaml
-    sha256: 745431a4c5b78cc93d81e99b2253a1e0eacd4f94e00cf17dab7cc14e665332e3
-  original: nightly-2022-03-30
+    sha256: eaf7fa19aa69d7e09d476232dab96dfc9c929dbc67f8a72aa38ec8b7b3827557
+    size: 529494
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/1/2.yaml
+  original: nightly-2024-01-02

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,11 +5,6 @@ packages:
   - bugsnag-wai
   - bugsnag-yesod
 
-extra-deps:
-  - annotated-exception-0.2.0.5
-  # For weeder
-  - algebraic-graphs-0.5
-
 ghc-options:
   "$locals": >
     -fwrite-ide-info

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-  - completed:
-      hackage: annotated-exception-0.2.0.5@sha256:d8d343f556e67ac38c8b5c8b9a1d551dd8005f6d28fe9c2accd606c5f9070e24,1785
-      pantry-tree:
-        sha256: 7e8f91d0899402a6ede549e6a47b169fdc9bb9877f4fe52471c2f43ef05eb167
-        size: 776
-    original:
-      hackage: annotated-exception-0.2.0.5
-  - completed:
-      hackage: algebraic-graphs-0.5@sha256:6eeec5ed1687ff7aa916e7bf9f02f51aaabde6f314dc0b7b1a84156974d7da73,8071
-      pantry-tree:
-        sha256: cca4a0348bb126506cacd8436948a68aad62e75d45df8c71f4090a00e69b45ee
-        size: 4128
-    original:
-      hackage: algebraic-graphs-0.5
+packages: []
 snapshots:
-  - completed:
-      sha256: 64d66303f927e87ffe6b8ccf736229bf608731e80d7afdf62bdd63c59f857740
-      size: 640037
-      url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/11.yaml
-    original: lts-21.11
+- completed:
+    sha256: 64d66303f927e87ffe6b8ccf736229bf608731e80d7afdf62bdd63c59f857740
+    size: 640037
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/11.yaml
+  original: lts-21.11


### PR DESCRIPTION
- Bump nightly version
- Re-organize stack resolver files
- Disable new warning in 9.8
